### PR TITLE
Rat opmode

### DIFF
--- a/actuators.py
+++ b/actuators.py
@@ -142,3 +142,11 @@ class Servo:
         self._robot = robot
     def set_position(self, position):
         self._robot.set_value(self._controller, "servo" + self._servo, position)
+
+
+class DistanceSensor:
+    def __init__(self, robot, device):
+        self._robot = robot
+        self._device = device
+    def get_distance(self):
+        return self._robot.get_value(self._device, "distance")

--- a/layer/drive.py
+++ b/layer/drive.py
@@ -110,6 +110,11 @@ class TwoWheelDrive(Layer):
             max_abs_power = max(abs(left), abs(right), 1)
             self._left_wheel.set_velocity(left * self._get_left_max_velocity() / max_abs_power)
             self._right_wheel.set_velocity(right * self._get_right_max_velocity() / max_abs_power)
+            Robot.set_value(
+                '6_2855048599430518311',
+                'velocity_a',
+                -1 * (Gamepad.get_value('dpad_up') - Gamepad.get_value('dpad_down'))
+            )
             #if time.time() - self._last_printed > 1:
             #    self._last_printed = time.time()
             #    self._logger.info(

--- a/layer/drive.py
+++ b/layer/drive.py
@@ -8,13 +8,12 @@ from task.drive import AxialMovementTask
 from task.drive import TankDriveTask
 from task.drive import TurnTask
 from units import convert
-import time
 
 
 class TwoWheelDrive(Layer):
     """Drive layer for a two-wheel drive robot."""
 
-    DRIVE_MOTOR_NAME = '6_12376238276098875264'
+    DRIVE_MOTOR_NAME = '6_6029077965246370240'
     WHEEL_RADIUS = convert(2, 'in', 'm')
     # Wheel teeth / hub teeth:
     GEAR_RATIO = 84 / 36

--- a/layer/drive.py
+++ b/layer/drive.py
@@ -14,8 +14,7 @@ import time
 class TwoWheelDrive(Layer):
     """Drive layer for a two-wheel drive robot."""
 
-    LEFT_DRIVE_MOTOR_NAME = '6_6029077965246370240'
-    RIGHT_DRIVE_MOTOR_NAME = '6_6029077965246370240'
+    DRIVE_MOTOR_NAME = '6_12376238276098875264'
     WHEEL_RADIUS = convert(2, 'in', 'm')
     # Wheel teeth / hub teeth:
     GEAR_RATIO = 84 / 36
@@ -48,7 +47,7 @@ class TwoWheelDrive(Layer):
             Motor(
                 setup_info.get_robot(),
                 setup_info.get_logger('Right wheel motor'),
-                self.RIGHT_DRIVE_MOTOR_NAME,
+                self.DRIVE_MOTOR_NAME,
                 'a'
             ).set_invert(True).set_encoder_invert(False),
             self.WHEEL_RADIUS,
@@ -59,7 +58,7 @@ class TwoWheelDrive(Layer):
             Motor(
                 setup_info.get_robot(),
                 setup_info.get_logger('Left wheel motor'),
-                self.LEFT_DRIVE_MOTOR_NAME,
+                self.DRIVE_MOTOR_NAME,
                 'b'
             ).set_invert(False).set_encoder_invert(False),
             self.WHEEL_RADIUS,

--- a/layer/drive.py
+++ b/layer/drive.py
@@ -13,7 +13,8 @@ from units import convert
 class TwoWheelDrive(Layer):
     """Drive layer for a two-wheel drive robot."""
 
-    DRIVE_MOTOR_NAME = '6_6029077965246370240'
+    DRIVE_MOTOR_NAME_LEFT = "6_8847060420572259627"
+    DRIVE_MOTOR_NAME = '6_16448980913872547624'
     WHEEL_RADIUS = convert(2, 'in', 'm')
     # Wheel teeth / hub teeth:
     GEAR_RATIO = 84 / 36
@@ -47,7 +48,7 @@ class TwoWheelDrive(Layer):
                 setup_info.get_robot(),
                 setup_info.get_logger('Right wheel motor'),
                 self.DRIVE_MOTOR_NAME,
-                'a'
+                'b'
             ).set_invert(True).set_encoder_invert(False),
             self.WHEEL_RADIUS,
             self.RIGHT_INTERNAL_GEARING * self.TICKS_PER_REV
@@ -57,8 +58,8 @@ class TwoWheelDrive(Layer):
             Motor(
                 setup_info.get_robot(),
                 setup_info.get_logger('Left wheel motor'),
-                self.DRIVE_MOTOR_NAME,
-                'b'
+                self.DRIVE_MOTOR_NAME_LEFT,
+                'a'
             ).set_invert(False).set_encoder_invert(False),
             self.WHEEL_RADIUS,
             self.LEFT_INTERNAL_GEARING * self.TICKS_PER_REV
@@ -110,14 +111,10 @@ class TwoWheelDrive(Layer):
             self._left_wheel.set_velocity(left * self._get_left_max_velocity() / max_abs_power)
             self._right_wheel.set_velocity(right * self._get_right_max_velocity() / max_abs_power)
             Robot.set_value(
-                '6_2855048599430518311',
+                '6_16448980913872547624',
                 'velocity_a',
                 -1 * (Gamepad.get_value('dpad_up') - Gamepad.get_value('dpad_down'))
             )
-            #if time.time() - self._last_printed > 1:
-            #    self._last_printed = time.time()
-            #    self._logger.info(
-            #        f'left {left * self._get_left_max_velocity() / max_abs_power} right {right * self._get_right_max_velocity() / max_abs_power}')
         elif isinstance(task, AxialMovementTask):
             self._should_request_task = False
             self._left_goal_delta = task.get_distance() * self.GEAR_RATIO * self.LEFT_ENCODER_FAC

--- a/layer/mapping.py
+++ b/layer/mapping.py
@@ -22,6 +22,10 @@ class TankDriveMapping(AbstractFunctionLayer):
 class ZeldaDriveMapping(AbstractFunctionLayer):
     def setup(self, setup_info):
         self._logger = setup_info.get_logger('ZeldaDriveMapping')
+        self._gp_fwd = 0
+        self._gp_ccw = 0
+        self._kb_fwd = 0
+        self._kb_ccw = 0
 
     def get_input_tasks(self):
         return {GamepadInputTask, KeyboardInputTask}
@@ -31,13 +35,15 @@ class ZeldaDriveMapping(AbstractFunctionLayer):
 
     def map(self, task):
         if isinstance(task, GamepadInputTask):
-            fwd = task.joysticks.left.y
-            cw = task.joysticks.left.x
+            self._gp_fwd = task.joysticks.left.y
+            self._gp_ccw = -task.joysticks.left.x
         elif isinstance(task, KeyboardInputTask):
-            fwd = task.get('w') - task.get('s')
-            cw = task.get('d') - task.get('a')
+            self._kb_fwd = task.get('w') - task.get('s')
+            self._kb_ccw = task.get('a') - task.get('d')
         else:
             raise TypeError(f'Bad task type of {task}')
-        left = fwd + cw
-        right = fwd - cw
+        fwd = self._gp_fwd if abs(self._gp_fwd > self._kb_fwd) else self._kb_fwd
+        ccw = self._gp_ccw if abs(self._gp_ccw > self._kb_ccw) else self._kb_ccw
+        left = fwd - ccw
+        right = fwd + ccw
         return TankDriveTask(left, right)

--- a/layer/mapping.py
+++ b/layer/mapping.py
@@ -3,6 +3,7 @@ from task.drive import HolonomicDriveTask
 from task.drive import TankDriveTask
 from task.input import GamepadInputTask
 from task.input import KeyboardInputTask
+from task.peripheral import BeltTask
 
 
 class TankDriveMapping(AbstractFunctionLayer):
@@ -47,3 +48,30 @@ class ZeldaDriveMapping(AbstractFunctionLayer):
         left = fwd - ccw
         right = fwd + ccw
         return TankDriveTask(left, right)
+
+
+class DpadBeltMapping(AbstractFunctionLayer):
+    def get_input_tasks(self):
+        return {GamepadInputTask, KeyboardInputTask}
+
+    def get_output_tasks(self):
+        return {BeltTask}
+
+    def map(self, task):
+        if isinstance(task, GamepadInputTask):
+            return DriveBeltTask(task.dpad.up - task.dpad.down)
+        elif isinstance(task, KeyboardInputTask):
+            return DriveBeltTask(task.get('o') - task.get('p'))
+        else:
+            raise TypeError(f'Bad task type of {task}')
+
+# left trigger drives quickly, right trigger drives slowly
+class TriggerBeltMapping(AbstractFunctionLayer):
+    def get_input_tasks(self):
+        return {GamepadInputTask}
+
+    def get_output_tasks(self):
+        return {BeltTask}
+
+    def map(self, task):
+        return DriveBeltTask(max(task.triggers.left * 1.up - task.dpad.down)

--- a/layer/peripheral.py
+++ b/layer/peripheral.py
@@ -1,2 +1,29 @@
-# belt motor is 6_3008899486804881237, inverted
-# left trigger drives quickly, right trigger drives slowly
+
+
+
+class BeltLayer(Layer):
+    def __init__(self, motor_controller):
+        self._motor_controller = motor_controller
+
+    def setup(self, setup_info):
+        self._motor = Motor(
+            setup_info.get_robot(),
+            self._motor_controller,
+            'a'
+        ).set_invert(True)
+
+    def get_input_tasks(self):
+        return {DriveBeltTask}
+
+    def get_output_tasks(self):
+        return set()
+
+    def process(self, ctx):
+        if self._task:
+            ctx.complete_task(self._task)
+            self._task = None
+        ctx.request_task()
+
+    def accept_task(self, task):
+        self._task = task
+        self._motor.set_velocity(task.get_power())

--- a/layer/strategy.py
+++ b/layer/strategy.py
@@ -1,0 +1,45 @@
+from layer import Layer
+from actuators import DistanceSensor
+from task.drive import TankDriveTask
+from task import WinTask
+
+
+class RatStrategy(Layer):
+    NOISE_THRESHOLD = 2
+    STOP_THRESHOLD = 3
+    DRIVE_SPEED = 0.1
+    SENSOR_ID = "8_4126596456779635307"
+
+    def setup(self, setup_info):
+        self._sensor = DistanceSensor(setup_info.get_robot(), self.SENSOR_ID)
+        self._accepted_task = None
+        self._emitted_task = None
+        self._finished = True
+
+    def get_input_tasks(self):
+        return {WinTask}
+
+    def get_output_tasks(self):
+        return {TankDriveTask}
+
+    def subtask_completed(self, task):
+        if task == self._emitted_task:
+            self._emitted_task = None
+
+    def process(self, ctx):
+        if self._finished:
+            if self._accepted_task:
+                ctx.complete_task(self._accepted_task)
+                self._accepted_task = None
+            ctx.request_task()
+            return
+        if not self._emitted_task:
+            self._finished = self.NOISE_THRESHOLD < self._sensor.get_distance() < self.STOP_THRESHOLD
+            speed = 0 if self._finished else self.DRIVE_SPEED
+            self._emitted_task = TankDriveTask(speed, speed)
+            ctx.emit_subtask(self._emitted_task)
+
+    def accept_task(self, task):
+        if isinstance(task, WinTask):
+            self._accepted_task = task
+            self._finished = False

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from log import Logger
 from log import LoggerProvider
 from log import StdioBackend
 
-auto_opmode = opmodes.SampleAutonomousOpmode()
+auto_opmode = opmodes.RatAutonomousOpmode()
 teleop_opmode = opmodes.TwoWheelDriveTeleopOpmode()
 
 FORCE_MOCK_ROBOT = False

--- a/opmodes.py
+++ b/opmodes.py
@@ -15,6 +15,7 @@ from task import WinTask
 from task.drive import AxialMovementTask
 from task.drive import TurnTask
 import math
+import time
 
 class AbstractOpmode(ABC):
     @abstractmethod
@@ -50,8 +51,13 @@ class AbstractOpmode(ABC):
         )
 
         self._finished = False
+        self._logger.log('Setup finished.')
+        self._init_time = time.time()
 
     def loop(self):
+        if self._init_time and time.time() - self._init_time > 5:
+            self._logger.log('Robot is alive 5 seconds into opmode')
+            self._init_time = None
         if not self._finished and self._controller.update():
             self._logger.warn('Opmode finished.')
             self._finished = True

--- a/opmodes.py
+++ b/opmodes.py
@@ -68,6 +68,7 @@ class TwoWheelDriveTeleopOpmode(AbstractOpmode):
     def get_layers(self, gamepad, keyboard):
         lg = LayerGraph()
         zelda = ZeldaDriveMapping()
+        BELT_MOTOR_CONTROLLER = '6_16448980913872547624'
         lg.add_chain([GamepadInputGenerator(gamepad), zelda, TwoWheelDrive()])
         #lg.add_connection(KeyboardInputGenerator(keyboard), zelda)
         return lg

--- a/opmodes.py
+++ b/opmodes.py
@@ -10,6 +10,7 @@ from layer.input import GamepadInputGenerator
 from layer.input import XboxGamepadInputGenerator
 from layer.mapping import TankDriveMapping
 from layer.mapping import ZeldaDriveMapping
+from layer.strategy import RatStrategy
 from log import LoggerProvider
 from task import WinTask
 from task.drive import AxialMovementTask
@@ -62,7 +63,7 @@ class TwoWheelDriveTeleopOpmode(AbstractOpmode):
         lg = LayerGraph()
         zelda = ZeldaDriveMapping()
         lg.add_chain([GamepadInputGenerator(gamepad), zelda, TwoWheelDrive()])
-        lg.add_connection(KeyboardInputGenerator(keyboard), zelda)
+        #lg.add_connection(KeyboardInputGenerator(keyboard), zelda)
         return lg
 
     def get_robot_spec(self):
@@ -93,6 +94,18 @@ class SampleProgrammedDriveLayer(AbstractQueuedLayer):
     def map_to_subtasks(self, task):
         assert(isinstance(task, WinTask))
         return [AxialMovementTask(1), TurnTask(math.pi / 2)] * 4
+
+
+class RatAutonomousOpmode(AbstractOpmode):
+    def get_layers(self, gamepad, keyboard):
+        lg = LayerGraph()
+        lg.add_chain([WinLayer(), RatStrategy(), TwoWheelDrive()])
+        return lg
+
+    def get_robot_spec(self):
+        return {
+            'koalabear': 1
+        }
 
 
 class NoopAutonomousOpmode(AbstractOpmode):


### PR DESCRIPTION
Add an autonomous opmode that drives forward until the distance sensor reaches a low enough reading.
- Add DistanceSensor device in actuators.py.
- Change motor controller IDs for new controllers.
- Hackily add belt control inside TwoWheelDrive process method.
- Attempt to fix TankDriveMapping failing to handle both gamepad and keyboard input layers simultaneously.
- Add RatAutonomousOpmode which functions as described above.
- Add belt layers and tasks for more appropriate belt control, but don’t use them yet.